### PR TITLE
[fix] - show NoMatch message

### DIFF
--- a/src/components/NoMatch/index.js
+++ b/src/components/NoMatch/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const NoMatch = () => (
-  <div>404</div>
+  <div className="content">404</div>
 );
 
 export default NoMatch;


### PR DESCRIPTION
I noticed that 404 message isn't appears. This happened because container needs padding-top. Otherwise is hidden under menu. So here is the fix.
Good job with this starter-kit. Keep it going! ;) 👍 
